### PR TITLE
Feature/fix GitHub action pr decorator

### DIFF
--- a/.github/workflows/lint_unitest.yml
+++ b/.github/workflows/lint_unitest.yml
@@ -46,7 +46,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          author_name: GitHubAction CI for NPM package to publish
+          author_name: GitHubAction CI for lint/unit test
           mention: 'here'
           if_mention: failure,cancelled
           fields: repo,commit,eventName,ref,workflow,message

--- a/.github/workflows/lint_unitest.yml
+++ b/.github/workflows/lint_unitest.yml
@@ -25,7 +25,9 @@ jobs:
 
       # Install Dependencies 
       - name: Install dependencies
-        run: echo SLACK_WEBHOOK_URL
+        run: echo $SLACK_WEBHOOK_URL
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         
 #       - name: Install dependencies
 #         run:  npm ci
@@ -41,30 +43,30 @@ jobs:
 #           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
 #           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
      
-      # Run Slack Notification
-      - name: Slack Notification
-        if: always() # Pick up events even if the job fails or is canceled.
-        uses: 8398a7/action-slack@v3
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          author_name: GitHubAction CI for lint/unit test
-          mention: 'here'
-          if_mention: failure,cancelled
-          fields: repo,commit,eventName,ref,workflow,message
-          custom_payload: |
-            {
-            username: 'GitHub Action CI WorkFlow',
-            icon_emoji: ':github:',
-            attachments: [{
-              color: '${{ job.status }}' === 'success' ? 'good' : ${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              text:
-             `${process.env.AS_REPO}\n
-              ${process.env.AS_COMMIT}\n 
-              ${process.env.AS_EVENT_NAME}\n
-              @${process.env.AS_REF}\n
-              @${process.env.AS_WORKFLOW}\n
-              ${process.env.AS_MESSAGE}`,
-            }]
-            }
+#       # Run Slack Notification
+#       - name: Slack Notification
+#         if: always() # Pick up events even if the job fails or is canceled.
+#         uses: 8398a7/action-slack@v3
+#         env:
+#           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#         with:
+#           status: ${{ job.status }}
+#           author_name: GitHubAction CI for lint/unit test
+#           mention: 'here'
+#           if_mention: failure,cancelled
+#           fields: repo,commit,eventName,ref,workflow,message
+#           custom_payload: |
+#             {
+#             username: 'GitHub Action CI WorkFlow',
+#             icon_emoji: ':github:',
+#             attachments: [{
+#               color: '${{ job.status }}' === 'success' ? 'good' : ${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+#               text:
+#              `${process.env.AS_REPO}\n
+#               ${process.env.AS_COMMIT}\n 
+#               ${process.env.AS_EVENT_NAME}\n
+#               @${process.env.AS_REF}\n
+#               @${process.env.AS_WORKFLOW}\n
+#               ${process.env.AS_MESSAGE}`,
+#             }]
+#             }

--- a/.github/workflows/lint_unitest.yml
+++ b/.github/workflows/lint_unitest.yml
@@ -25,18 +25,21 @@ jobs:
 
       # Install Dependencies 
       - name: Install dependencies
-        run:  npm ci
+        run: echo SLACK_WEBHOOK_URL
+        
+#       - name: Install dependencies
+#         run:  npm ci
 
-      # Run tests
-      - name: Run unit tests
-        run:  npm test
+#       # Run tests
+#       - name: Run unit tests
+#         run:  npm test
 
-      # Run Sonarcloudscan
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#       # Run Sonarcloudscan
+#       - name: SonarCloud Scan
+#         uses: SonarSource/sonarcloud-github-action@master
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+#           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
      
       # Run Slack Notification
       - name: Slack Notification

--- a/.github/workflows/lint_unitest.yml
+++ b/.github/workflows/lint_unitest.yml
@@ -25,9 +25,9 @@ jobs:
 
       # Install Dependencies 
       - name: Install dependencies
-        run: echo $SLACK_WEBHOOK_URL
+        run: echo $SONAR_TOKEN
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         
 #       - name: Install dependencies
 #         run:  npm ci

--- a/.github/workflows/lint_unitest.yml
+++ b/.github/workflows/lint_unitest.yml
@@ -5,14 +5,18 @@ name: SonarCloud CI Unit Test
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the develop branch
 on:
-  push:
-    branches: [ develop ]
   pull_request:
-    branches: [ trunk, develop ]
-    types: [opened, synchronize, reopened]
+    types: [assigned, opened, synchronize, reopened]
+    branches:
+      - trunk
+      - develop
+  push:
+    branches:
+      - develop
+      - feature/*
 jobs:
-  sonarcloud:
-    name: SonarCloud
+  build:
+    name: SonarCloud GithubAction
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -33,3 +37,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+     
+      # Run Slack Notification
+      - name: Slack Notification
+        if: always() # Pick up events even if the job fails or is canceled.
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          author_name: GitHubAction CI for NPM package to publish
+          mention: 'here'
+          if_mention: failure,cancelled
+          fields: repo,commit,eventName,ref,workflow,message
+          custom_payload: |
+            {
+            username: 'GitHub Action CI WorkFlow',
+            icon_emoji: ':github:',
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : ${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              text:
+             `${process.env.AS_REPO}\n
+              ${process.env.AS_COMMIT}\n 
+              ${process.env.AS_EVENT_NAME}\n
+              @${process.env.AS_REF}\n
+              @${process.env.AS_WORKFLOW}\n
+              ${process.env.AS_MESSAGE}`,
+            }]
+            }

--- a/.github/workflows/lint_unitest.yml
+++ b/.github/workflows/lint_unitest.yml
@@ -22,51 +22,45 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-
-      # Install Dependencies 
-      - name: Install dependencies
-        run: echo $SONAR_TOKEN
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         
-#       - name: Install dependencies
-#         run:  npm ci
+      - name: Install dependencies
+        run:  npm ci
 
-#       # Run tests
-#       - name: Run unit tests
-#         run:  npm test
+      # Run tests
+      - name: Run unit tests
+        run:  npm test
 
-#       # Run Sonarcloudscan
-#       - name: SonarCloud Scan
-#         uses: SonarSource/sonarcloud-github-action@master
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-#           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      # Run Sonarcloudscan
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
      
-#       # Run Slack Notification
-#       - name: Slack Notification
-#         if: always() # Pick up events even if the job fails or is canceled.
-#         uses: 8398a7/action-slack@v3
-#         env:
-#           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#         with:
-#           status: ${{ job.status }}
-#           author_name: GitHubAction CI for lint/unit test
-#           mention: 'here'
-#           if_mention: failure,cancelled
-#           fields: repo,commit,eventName,ref,workflow,message
-#           custom_payload: |
-#             {
-#             username: 'GitHub Action CI WorkFlow',
-#             icon_emoji: ':github:',
-#             attachments: [{
-#               color: '${{ job.status }}' === 'success' ? 'good' : ${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-#               text:
-#              `${process.env.AS_REPO}\n
-#               ${process.env.AS_COMMIT}\n 
-#               ${process.env.AS_EVENT_NAME}\n
-#               @${process.env.AS_REF}\n
-#               @${process.env.AS_WORKFLOW}\n
-#               ${process.env.AS_MESSAGE}`,
-#             }]
-#             }
+      # Run Slack Notification
+      - name: Slack Notification
+        if: always() # Pick up events even if the job fails or is canceled.
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          author_name: GitHubAction CI for lint/unit test
+          mention: 'here'
+          if_mention: failure,cancelled
+          fields: repo,commit,eventName,ref,workflow,message
+          custom_payload: |
+            {
+            username: 'GitHub Action CI WorkFlow',
+            icon_emoji: ':github:',
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : ${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              text:
+             `${process.env.AS_REPO}\n
+              ${process.env.AS_COMMIT}\n 
+              ${process.env.AS_EVENT_NAME}\n
+              @${process.env.AS_REF}\n
+              @${process.env.AS_WORKFLOW}\n
+              ${process.env.AS_MESSAGE}`,
+            }]
+            }

--- a/.github/workflows/npm_package_publish.yml
+++ b/.github/workflows/npm_package_publish.yml
@@ -16,3 +16,31 @@ jobs:
     - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    
+    # Run Slack Notification
+    - name: Slack Notification
+      if: always() # Pick up events even if the job fails or is canceled.
+      uses: 8398a7/action-slack@v3
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        status: ${{ job.status }}
+        author_name: NPM package attempt to publish
+        mention: 'here'
+        if_mention: failure,cancelled
+        fields: repo,commit,eventName,ref,workflow,message
+        custom_payload: |
+          {
+          username: 'GitHub Action CI WorkFlow',
+          icon_emoji: ':github:',
+          attachments: [{
+            color: '${{ job.status }}' === 'success' ? 'good' : ${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+            text:
+            `${process.env.AS_REPO}\n
+            ${process.env.AS_COMMIT}\n 
+            ${process.env.AS_EVENT_NAME}\n
+            @${process.env.AS_REF}\n
+            @${process.env.AS_WORKFLOW}\n
+            ${process.env.AS_MESSAGE}`,
+          }]
+          }

--- a/.github/workflows/npm_package_publish.yml
+++ b/.github/workflows/npm_package_publish.yml
@@ -17,6 +17,13 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     
+  # Run Sonarcloudscan
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    
     # Run Slack Notification
     - name: Slack Notification
       if: always() # Pick up events even if the job fails or is canceled.
@@ -25,7 +32,7 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
         status: ${{ job.status }}
-        author_name: NPM package attempt to publish
+        author_name: GitHubAction CI for npm publish
         mention: 'here'
         if_mention: failure,cancelled
         fields: repo,commit,eventName,ref,workflow,message


### PR DESCRIPTION
**Story/Ticket Reference ID from JIRA:**
`Add link here`

**Additional Comments:**
`Add minor changes to GitHub action workflow
We faced an earlier Sonarcloudbot issue not decorating our PR could be because Sonarcloud understood it as branch analysis instead of pull request analysis. It can happen when we make a commit/push to a branch and that branch is requested for PR. If it still issues will look into`

**Checklist:**

- [ x ] Unit test completed?: (Y/N)
- [ x ] Docs folder up to date?: (Y/N)
- [ x ] Add if anything missed: (Y/N)
- [ x ] Add if anything missed: (Y/N)

All Checklist are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)